### PR TITLE
v1.2

### DIFF
--- a/globals.cpp
+++ b/globals.cpp
@@ -10,6 +10,8 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 
 #include <QString>
 #include <QDebug>
+#include <QApplication>
+#include <QCoreApplication>
 
 #include "rpc.h"
 #include "rpcdce.h"
@@ -24,8 +26,9 @@ extern "C"{
 #pragma comment(lib, "Ole32.lib")
 
 //Misc
-const DWORD autoStartDetectTime = 60000; //if uptime > this, show the application window when starting
 const QString applicationName = "Auto Power Plan";   //Used for application settings
+const QString regStartupPath = "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+const QString autoStartArg = "-hide";
 
 //Clamps
 const int minUpdateFreq = 5;
@@ -36,16 +39,14 @@ const QString settingsPwrPlnBatFrndName_Name = "Plans/Battery";
 const QString settingsPwrPlnACFrndName_Name = "Plans/AC";
 const QString settingsUpdateFreq_Name = "UpdateFrequency";
 const QString settingsHasRun_Name = "HasRun";
-const QString settingsAutoStart_Name = "AutoStart";
 
 //Settings default values
-//!!!!!NOTE!!!!!
+//Please note:
     //friendlyName is the value saved to file for the power plans
 const QString settingsDefPwrPlnBatFrndName_Value = "Balanced";
 const QString settingsDefPwrPlnACFrndName_Value = "High Performance";
 const int settingsDefUpdateFreq_Value = 15;
 const bool settingsDefHasRun_Value = true;
-const bool settingsDefAutoStart_Value = true;
 
 
 //Misc Functions

--- a/globals.h
+++ b/globals.h
@@ -14,8 +14,9 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 #include "Windows.h"
 
 //Misc
-extern const DWORD autoStartDetectTime;
 extern const QString applicationName;
+extern const QString regStartupPath;    //Path of the registry key for autostart
+extern const QString autoStartArg;      //Arg used to indicate auto start
 
 //Clamps
 extern const int minUpdateFreq;
@@ -26,14 +27,12 @@ extern const QString settingsPwrPlnBatFrndName_Name;
 extern const QString settingsPwrPlnACFrndName_Name;
 extern const QString settingsUpdateFreq_Name;
 extern const QString settingsHasRun_Name;
-extern const QString settingsAutoStart_Name;
 
 //Default value of the settings
 extern const QString settingsDefPwrPlnBatFrndName_Value;
 extern const QString settingsDefPwrPlnACFrndName_Value;
 extern const int settingsDefUpdateFreq_Value;
 extern const bool settingsDefHasRun_Value;
-extern const bool settingsDefAutoStart_Value;
 
 
 //Default Power Schemes

--- a/main.cpp
+++ b/main.cpp
@@ -20,6 +20,8 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 #include <QApplication>
 #include <QString>
 #include <QSettings>
+#include <QDebug>
+
 #include "rpc.h"
 #include "rpcdce.h"
 #include "Windows.h"
@@ -65,12 +67,15 @@ int main(int argc, char *argv[])
     //Set values used for QSettings
     QCoreApplication::setOrganizationName(applicationName);
     QCoreApplication::setApplicationName(applicationName);
+    MainWindow w;
 
-    bool showWindow = false;
+
+    bool showWindow = true;
 
     //Check if application was auto started by windows or by user
-    if(GetTickCount() > autoStartDetectTime){
-        showWindow = true; //Uptime longer than autoStartDetectTime, assumed to not have been auto started
+    if(argv[1] == autoStartArg){
+        //AutoStarted
+        showWindow = false;
     }
 
 
@@ -82,7 +87,6 @@ int main(int argc, char *argv[])
 
 
 
-    MainWindow w;
 
     //Show window if first run or if manually started
     if(showWindow){

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -307,7 +307,7 @@ bool MainWindow::willAutoStart(void){
     QSettings bootSettings(regStartupPath, QSettings::NativeFormat);
     if(! bootSettings.value(applicationName).toBool()){
         //No autostart key found
-        qDebug() << "Remove me, no key found";
+        qDebug() << "No autostart key found";
         return false;
     }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -41,7 +41,8 @@ private:
     void writeToSettings(QString settingName, QString settingValue);
     void writeToSettings(QString settingName, int settingValue);
     void writeToSettings(QString settingName, bool settingValue);
-    void updateAutoStartSetting();
+    void setAutoStart(bool autoStart);
+    bool willAutoStart(void);
 
     Ui::MainWindow *ui;
 };


### PR DESCRIPTION
Program wide changes:
The setting "AutoStart" (settingsAutoStart_Name, settingsDefAutoStart_Value) are no longer used. A command line argument is now used to determine if the application was auto started.


main.cpp:
Defined regStartupValue
Removed uptime based auto start detection, replaced with command arg detection.


mainwindow.cpp:
Changed updateAutoStartSetting to setAutoStart. Now takes a bool as an argument.
Created function willAutoStart, takes no arguments, returns a bool indicating if the program is set to auto start.
onAutoStartComboBoxSelected modified to work with new functions.
Removed deprecated settings(autoStart settings)
Changed code for Auto start dropdown to not use deprecated settings


mainwindow.h:
Changed updateAutoStartSetting to setAutoStart
Added function willAutoStart


globals.cpp
Defined regStartupPath(registry path for autoStartArgs)
Defined autoStartArg(arg used to hide application on startup)
Removed autoStartDetectTime
Removed settingsDefAutoStart_Value
Removed settingsAutoStart_Name


globals.h:
Added regStartupPath
Removed settingsAutoStart_Name
Removed settingsDefAutoStart_Value
Removed autoStartDetectTime